### PR TITLE
Live footprint calculation

### DIFF
--- a/app/assets/stylesheets/components/_long_form.scss
+++ b/app/assets/stylesheets/components/_long_form.scss
@@ -11,7 +11,11 @@
   .form-control.is-valid {
     border-color: black
   }
+  .form-text {
+    font-weight: lighter;
+  }
 }
+
 .inner-form {
   display: flex;
   justify-content: center;
@@ -26,7 +30,10 @@
 
 .container-long-form {
   height: 100vh;
-  overflow: hidden;
+  &-inner {
+    height: 100%;
+    overflow: hidden;
+  }
 }
 
 .span {
@@ -46,4 +53,19 @@
   font-size: smaller;
   font-weight: lighter;
   text-align: center;
+}
+
+.long-form-results-container {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 250px;
+  background-color: RGB(145, 199, 136);
+  padding: 2rem;
+  border-radius: 1rem 0 0 1rem;
+  color: white;
+  .hint {
+    font-size: 0.75rem;
+  }
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import "bootstrap"
 
+import { FootprintCalculator } from './services/footprint_calculator'

--- a/app/javascript/controllers/long_form_controller.js
+++ b/app/javascript/controllers/long_form_controller.js
@@ -2,9 +2,51 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="long-form"
 export default class extends Controller {
-  static targets = ["screen", "form"]
+  static targets = [
+    "screen",
+    "form",
+    'ghgResult',
+    'currentInputValueResult',
+    'scope1Result',
+    'scope2Result',
+    'scope3Result'
+  ]
+  static values= {
+    company: Object,
+    baseValues: Object,
+    steps: Array
+  }
+
   connect() {
+    console.log(this.baseValuesValue)
+    this.calculator = new FootprintCalculator(this.companyValue, this.baseValuesValue)
     this.index = 0
+    this.#preventSubmitUntilEndReached()
+  }
+
+  back() {
+    if (this.index === 0) return
+    this.index--
+    const screen = this.screenTargets[this.index]
+    screen.scrollIntoView({behavior: "smooth"})
+    setTimeout(() => {
+      screen.querySelector("input").focus()
+      this.#cleanCurrentValues()
+    }, 500);
+
+  }
+
+  next() {
+    this.index++
+    const screen = this.screenTargets[this.index]
+    screen.scrollIntoView({behavior: "smooth"})
+    setTimeout(() => {
+      screen.querySelector("input").focus()
+      this.#cleanCurrentValues()
+    }, 500);
+  }
+
+  #preventSubmitUntilEndReached() {
     this.formTarget.addEventListener("submit", (event) => {
       if ( this.screenTargets.length === this.index + 1) {
         this.formTarget.submit()
@@ -15,22 +57,41 @@ export default class extends Controller {
     })
   }
 
-  back() {
-    if (this.index === 0) return
-    this.index--
-    const screen = this.screenTargets[this.index]
-    screen.scrollIntoView({behavior: "smooth"})
-    setTimeout(() => {
-      screen.querySelector("input").focus()
-    }, 500);
+  updateResult(event) {
+    const val = event.currentTarget.value
+    // if (isNaN(val)) return;
+    if (event.params.step === 'buildings') {
+      var currentValue = this.calculator.buildings(val)
+    } else if (event.params.step === 'gas') {
+      var currentValue = this.calculator.gas(val)
+    } else if (event.params.step === 'fuel') {
+      var currentValue = this.calculator.fuel(val)
+    } else if (event.params.step === 'gasoline') {
+      var currentValue = this.calculator.gasoline(val)
+    } else if (event.params.step === 'diesel') {
+      var currentValue = this.calculator.diesel(val)
+    } else if (event.params.step === 'electricity') {
+      var currentValue = this.calculator.electricity(val)
+    } else if (event.params.step === 'clientsFr') {
+      var currentValue = this.calculator.clientsFr(val)
+    } else if (event.params.step === 'clientsInt') {
+      var currentValue = this.calculator.clientsInt(val)
+    } else if (event.params.step === 'suppliers') {
+      var currentValue = this.calculator.suppliers(val)
+    }
+    this.#updateCurrentValues(currentValue)
+
+    this.ghgResultTarget.innerText = this.calculator.result()
+    this.scope1ResultTarget.innerText = this.calculator.scope1()
+    this.scope2ResultTarget.innerText = this.calculator.scope2()
+    this.scope3ResultTarget.innerText = this.calculator.scope3()
   }
 
-  next() {
-    this.index++
-    const screen = this.screenTargets[this.index]
-      screen.scrollIntoView({behavior: "smooth"})
-      setTimeout(() => {
-        screen.querySelector("input").focus()
-      }, 500);
+  #cleanCurrentValues() {
+    this.currentInputValueResultTargets.forEach(e => e.innerText = "0")
+  }
+
+  #updateCurrentValues(val) {
+    this.currentInputValueResultTargets.forEach(e => e.innerText = val)
   }
 }

--- a/app/javascript/controllers/long_form_controller.js
+++ b/app/javascript/controllers/long_form_controller.js
@@ -18,7 +18,6 @@ export default class extends Controller {
   }
 
   connect() {
-    console.log(this.baseValuesValue)
     this.calculator = new FootprintCalculator(this.companyValue, this.baseValuesValue)
     this.index = 0
     this.#preventSubmitUntilEndReached()
@@ -59,26 +58,20 @@ export default class extends Controller {
 
   updateResult(event) {
     const val = event.currentTarget.value
-    // if (isNaN(val)) return;
-    if (event.params.step === 'buildings') {
-      var currentValue = this.calculator.buildings(val)
-    } else if (event.params.step === 'gas') {
-      var currentValue = this.calculator.gas(val)
-    } else if (event.params.step === 'fuel') {
-      var currentValue = this.calculator.fuel(val)
-    } else if (event.params.step === 'gasoline') {
-      var currentValue = this.calculator.gasoline(val)
-    } else if (event.params.step === 'diesel') {
-      var currentValue = this.calculator.diesel(val)
-    } else if (event.params.step === 'electricity') {
-      var currentValue = this.calculator.electricity(val)
-    } else if (event.params.step === 'clientsFr') {
-      var currentValue = this.calculator.clientsFr(val)
-    } else if (event.params.step === 'clientsInt') {
-      var currentValue = this.calculator.clientsInt(val)
-    } else if (event.params.step === 'suppliers') {
-      var currentValue = this.calculator.suppliers(val)
+    if (val && !!val.match(/[^\d]/)) return
+
+    switch (event.params.step) {
+      case 'buildings':   { var currentValue = this.calculator.buildings(val); break; }
+      case 'gas':         { var currentValue = this.calculator.gas(val); break; }
+      case 'fuel':        { var currentValue = this.calculator.fuel(val); break; }
+      case 'gasoline':    { var currentValue = this.calculator.gasoline(val); break; }
+      case 'diesel':      { var currentValue = this.calculator.diesel(val); break; }
+      case 'electricity': { var currentValue = this.calculator.electricity(val); break; }
+      case 'clientsFr':   { var currentValue = this.calculator.clientsFr(val); break; }
+      case 'clientsInt':  { var currentValue = this.calculator.clientsInt(val); break; }
+      case 'suppliers':   { var currentValue = this.calculator.suppliers(val); break; }
     }
+
     this.#updateCurrentValues(currentValue)
 
     this.ghgResultTarget.innerText = this.calculator.result()

--- a/app/javascript/services/footprint_calculator.js
+++ b/app/javascript/services/footprint_calculator.js
@@ -1,0 +1,86 @@
+export class FootprintCalculator {
+  constructor(company, baseValues) {
+    this.gasVal             = baseValues.gasVal
+    this.buildingsVal       = baseValues.buildingsVal
+    this.electricityVal     = baseValues.electricityVal
+    this.fuelVal            = baseValues.fuelVal
+    this.gasolineVal        = baseValues.gasolineVal
+    this.dieselVal          = baseValues.dieselVal
+    this.clientsFrVal       = baseValues.clientsFrVal
+    this.clientsIntVal      = baseValues.clientsIntVal
+    this.suppliersVal       = baseValues.suppliersVal
+    this.groups             = 365 * company.room_nb * (company.load_factor / company.length_of_stay)
+    this.gasResult          = 0
+    this.fuelResult         = 0
+    this.gasolineResult     = 0
+    this.dieselResult       = 0
+    this.electricityResult  = 0
+    this.clientsFrResult    = 0
+    this.clientsIntResult   = 0
+    this.suppliersResult    = 0
+    this.buildingsResult    = 0
+  }
+
+  gas(val) {
+    return this.gasResult = this.#roundToDecimal(val * this.gasVal, 2)
+  }
+
+  fuel(val) {
+    return this.fuelResult = this.#roundToDecimal(val * this.fuelVal, 2)
+  }
+
+  buildings(val) {
+    return this.buildingsResult = this.#roundToDecimal(val * this.buildingsVal, 2)
+  }
+
+  gasoline(val) {
+    return this.gasolineResult = this.#roundToDecimal(val * 1.4 * this.gasolineVal, 2)
+  }
+
+  diesel(val) {
+    return this.dieselResult = this.#roundToDecimal(val * 1.2 * this.dieselVal, 2)
+  }
+
+  electricity(val) {
+    return this.electricityResult = this.#roundToDecimal(val * this.electricityVal, 2)
+  }
+
+  clientsFr(val) {
+    return this.clientsFrResult = this.#roundToDecimal((val / 100) * this.clientsFrVal * 0.0021 * this.groups, 2)
+  }
+
+  clientsInt(val) {
+    return this.clientsIntResult = this.#roundToDecimal((val / 100) * this.clientsIntVal * this.groups, 2)
+  }
+
+  suppliers(val) {
+    return this.suppliersResult = this.#roundToDecimal(val * 0.01 * this.suppliersVal, 2)
+  }
+
+  #buildingsSize() {
+    return this.result = this.#roundToDecimal(gas * this.buildingsVal, 2)
+  }
+
+  scope1() {
+    return this.#roundToDecimal(this.gasResult + this.fuelResult + this.gasolineResult + this.dieselResult, 2)
+  }
+
+  scope2() {
+    return this.#roundToDecimal(this.electricityResult, 2)
+  }
+
+  scope3() {
+    return this.#roundToDecimal(this.clientsFrResult + this.clientsIntResult + this.suppliersResult + this.buildingsResult, 2)
+  }
+
+  result() {
+    return this.#roundToDecimal(this.scope1() + this.scope2() + this.scope3(), 2)
+  }
+
+  #roundToDecimal(n, decimals = 0) {
+    return +(Math.round(n + `e+${decimals}`)  + `e-${decimals}`)
+  }
+}
+
+global.FootprintCalculator = FootprintCalculator
+

--- a/app/models/emission_factors.rb
+++ b/app/models/emission_factors.rb
@@ -1,11 +1,35 @@
 class EmissionFactors
-  GAZ = 0.2429
-  BATIMENTS = 0.011
-  ELECTRICITE = 0.06
-  FIOUL = 2.68
-  ESSENCE = 2.28
-  GAZOLE = 2.51
-  CLIENTFR = 2.4
-  CLIENTINT = 0.38
-  FOURNISSEURS = 2.51
+  GAZ           = 0.2429
+  BATIMENTS     = 0.011
+  ELECTRICITE   = 0.06
+  FIOUL         = 2.68
+  ESSENCE       = 2.28
+  GAZOLE        = 2.51
+  CLIENTFR      = 2.4
+  CLIENTINT     = 0.38
+  FOURNISSEURS  = 2.51
+
+  class << self
+    def to_json
+      constants.map do |e|
+        [to_json_en(e), const_get(e)]
+      end
+      .to_h
+      .to_json
+    end
+
+    def to_json_en(const_name)
+      case const_name
+      when :GAZ           then 'gasVal'
+      when :BATIMENTS     then 'buildingsVal'
+      when :ELECTRICITE   then 'electricityVal'
+      when :FIOUL         then 'fuelVal'
+      when :ESSENCE       then 'gasolineVal'
+      when :GAZOLE        then 'dieselVal'
+      when :CLIENTFR      then 'clientsFrVal'
+      when :CLIENTINT     then 'clientsIntVal'
+      when :FOURNISSEURS  then 'suppliersVal'
+      end
+    end
+  end
 end

--- a/app/views/footprints/new.html.erb
+++ b/app/views/footprints/new.html.erb
@@ -1,92 +1,176 @@
-<div class="container-long-form" data-controller="long-form">
-  <%= simple_form_for [@company, @footprint], html: {data: {long_form_target: "form"}} do |f| %>
-    <%# <h2>Scope 1</h2>
-      <h3>Bâtiments</h3> %>
-        <div class="long-form-div" data-long-form-target="screen">
-          <div class="inner-form">
-            <%= f.input :taille_batiments, label: "Quelle est la surface de vos locaux (en m²) ?", autofocus: true %>
-            <span class="span" data-action="click->long-form#next">Suivant</span>
-          </div>
-          <div class="astuce"></div>
-        </div>
+<div class="container-long-form"
+     data-controller="long-form"
+     data-long-form-company-value="<%= @company.to_json %>"
+     data-long-form-base-values-value="<%= EmissionFactors.to_json %>">
 
-        <div class="long-form-div" data-long-form-target="screen">
-          <div class="inner-form">
-            <%= f.input :gaz, label: "Quelle est votre consommation de gaz par an ? (en MWh/an) ?" %>
-            <span class="span" data-action="click->long-form#back">Précédent</span>
-            <span class="span" data-action="click->long-form#next">Suivant</span>
-          </div>
-          <div class="astuce">Astuce : comptez 240 MWh/1000 m²/an</div>
-        </div>
+  <div class="long-form-results-container">
+    <p class="mb-1 fw-bold fs-5 text-center">Emissions globales</p>
+    <p class="mb-2 fw-bold text-center"><span data-long-form-target="ghgResult">0</span>T CO²eq/an</p>
+    <hr>
+    <p class="mb-1 fw-bold text-center">Emissions scope 1</p>
+    <p class="mb-2 text-center"><span data-long-form-target="scope1Result">0</span>T CO²eq/an</p>
+    <hr>
+    <p class="mb-1 fw-bold text-center">Emissions scope 2</p>
+    <p class="mb-2 text-center"><span data-long-form-target="scope2Result">0</span>T CO²eq/an</p>
+    <hr>
+    <p class="mb-1 fw-bold text-center">Emissions scope 3</p>
+    <p class="mb-2 text-center"><span data-long-form-target="scope3Result">0</span>T CO²eq/an</p>
+    <hr>
+    <p class="hint">Valeurs en Tonnes de CO²eq/an</p>
+  </div>
 
-        <div class="long-form-div" data-long-form-target="screen">
-          <div class="inner-form">
-            <%= f.input :fioul, label: "Quelle est votre consommation de fioul par an ? (en milliers de litres/an) ?" %>
-            <span class="span" data-action="click->long-form#back">Précédent</span>
-            <span class="span" data-action="click->long-form#next">Suivant</span>
-          </div>
-          <div class="astuce">Astuce : comptez 2 milliers de litres/1000 m²/an</div>
-        </div>
+  <div class="container-long-form-inner">
+    <%= simple_form_for [@company, @footprint], html: {data: {long_form_target: "form"}} do |f| %>
 
-      <%# <h3>Véhicules</h3> %>
-        <div class="long-form-div" data-long-form-target="screen">
-          <div class="inner-form">
-            <%= f.input :essence, label: "Combien de salariés utilisent une voiture à essence ?" %>
-            <span class="span" data-action="click->long-form#back">Précédent</span>
-            <span class="span" data-action="click->long-form#next">Suivant</span>
-          </div>
-          <div class="astuce"></div>
-        </div>
-
-        <div class="long-form-div" data-long-form-target="screen">
-          <div class="inner-form">
-            <%= f.input :gazole, label: "Combien de salariés utilisent une voiture diesel ?" %>
-            <span class="span" data-action="click->long-form#back">Précédent</span>
-            <span class="span" data-action="click->long-form#next">Suivant</span>
-          </div>
-          <div class="astuce"></div>
-        </div>
-
-    <%# <h2>Scope 2</h2> %>
-      <%# <h3>Electricité</h3> %>
-        <div class="long-form-div" data-long-form-target="screen">
-          <div class="inner-form">
-            <%= f.input :electricite, label: "Quelle consommation d'électricité par an (en MWh/an) ?" %>
-            <span class="span" data-action="click->long-form#back">Précédent</span>
-            <span class="span" data-action="click->long-form#next">Suivant</span>
-          </div>
-          <div class="astuce">Astuce : comptez 240 MWh/1000 m²/an</div>
-        </div>
-
-    <%# <h2>Scope 3</h2> %>
       <div class="long-form-div" data-long-form-target="screen">
         <div class="inner-form">
-          <%= f.input :clients_fr, label: "Pourcentage de clients venant de France ? ex: Entrez 80 pour 80%" %>
-          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <%= f.input :taille_batiments,
+                      label: "Quelle est la surface de vos locaux (en m²) ?",
+                      autofocus: true,
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'buildings'
+                        }
+                      } %>
           <span class="span" data-action="click->long-form#next">Suivant</span>
         </div>
-          <div class="astuce">Aide : arrivant et repartant en véhicules thermiques - 300 km aller-retour</div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
       </div>
 
       <div class="long-form-div" data-long-form-target="screen">
         <div class="inner-form">
-          <%= f.input :clients_int, label: "Pourcentage de clients venant de l'étranger ? ex: Entrez 10 pour 10%" %>
+          <%= f.input :gaz,
+                      label: "Quelle est votre consommation de gaz par an ? (en MWh/an) ?",
+                      hint: 'comptez 240 MWh/1000 m²/an',
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'gas'
+                        }
+                      } %>
           <span class="span" data-action="click->long-form#back">Précédent</span>
           <span class="span" data-action="click->long-form#next">Suivant</span>
         </div>
-        <div class="astuce">Aide : arrivant et repartant en avion - 2 000 km aller-retour</div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
       </div>
 
       <div class="long-form-div" data-long-form-target="screen">
         <div class="inner-form">
-          <%= f.input :fournisseurs, label: "Combien avez-vous de fournisseurs ?" %>
+          <%= f.input :fioul,
+                      label: "Quelle est votre consommation de fioul par an ? (en milliers de litres/an) ?",
+                      hint: 'comptez 2 milliers de litres/1000 m²/an',
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'fuel'
+                        }
+                      } %>
           <span class="span" data-action="click->long-form#back">Précédent</span>
           <span class="span" data-action="click->long-form#next">Suivant</span>
         </div>
-        <div class="astuce"></div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
       </div>
 
-    <%# <h2>Voulez-vous certifier votre Bilan Carbone ?</h2> %>
+      <div class="long-form-div" data-long-form-target="screen">
+        <div class="inner-form">
+          <%= f.input :essence,
+                      label: "Combien de salariés utilisent une voiture à essence ?",
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'gasoline'
+                        }
+                      } %>
+          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <span class="span" data-action="click->long-form#next">Suivant</span>
+        </div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
+      </div>
+
+      <div class="long-form-div" data-long-form-target="screen">
+        <div class="inner-form">
+          <%= f.input :gazole,
+                      label: "Combien de salariés utilisent une voiture diesel ?",
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'diesel'
+                        }
+                      } %>
+          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <span class="span" data-action="click->long-form#next">Suivant</span>
+        </div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
+      </div>
+
+      <div class="long-form-div" data-long-form-target="screen">
+        <div class="inner-form">
+          <%= f.input :electricite,
+                      label: "Quelle consommation d'électricité par an (en MWh/an) ?",
+                      hint: 'comptez 240 MWh/1000 m²/an',
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'electricity'
+                        }
+                      } %>
+          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <span class="span" data-action="click->long-form#next">Suivant</span>
+        </div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
+      </div>
+
+      <div class="long-form-div" data-long-form-target="screen">
+        <div class="inner-form">
+          <%= f.input :clients_fr,
+                      label: "Pourcentage de clients venant de France ? ex: Entrez 80 pour 80%",
+                      hint: 'arrivant et repartant en véhicules thermiques - 300 km aller-retour',
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'clientsFr'
+                        }
+                      } %>
+          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <span class="span" data-action="click->long-form#next">Suivant</span>
+        </div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
+      </div>
+
+      <div class="long-form-div" data-long-form-target="screen">
+        <div class="inner-form">
+          <%= f.input :clients_int,
+                      label: "Pourcentage de clients venant de l'étranger ? ex: Entrez 10 pour 10%",
+                      hint: 'arrivant et repartant en avion - 2 000 km aller-retour',
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'clientsInt'
+                        }
+                      } %>
+          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <span class="span" data-action="click->long-form#next">Suivant</span>
+        </div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
+      </div>
+
+      <div class="long-form-div" data-long-form-target="screen">
+        <div class="inner-form">
+          <%= f.input :fournisseurs,
+                      label: "Combien avez-vous de fournisseurs ?",
+                      input_html: {
+                        data: {
+                          action: 'keyup->long-form#updateResult',
+                          long_form_step_param: 'suppliers'
+                        }
+                      } %>
+          <span class="span" data-action="click->long-form#back">Précédent</span>
+          <span class="span" data-action="click->long-form#next">Suivant</span>
+        </div>
+        <p class="mt-5 mb-0 text-center"><span data-long-form-target="currentInputValueResult">0</span>T CO²/an</p>
+      </div>
+
       <div class="long-form-div" data-long-form-target="screen">
         <div class="inner-form-certified">
           <%= f.input :certified, label: "Voulez-vous certifier ce bilan carbone ?"%>
@@ -97,5 +181,6 @@
         </div>
       </div>
 
-  <% end %>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
- Added an info window in the long-form to display current results from user inputs dynamically
- Text from `astuces` has been moved to inputs' `hints`
- Astuces is now displaying the current input's carbon emission result
- Added a Javascript service that calculates footprint result the same way as the ruby service
- There's still only one truth source for EmissionFactors constants (see `app/models/emission_factors.rb`) (maybe add the multiplication factors there too?)

I'm not sure about the text I've displayed to describe the dynamic results, I think it should be changed.
The alignment of the next/previous buttons with the input could be a nice to have. 

<img width="2048" alt="Capture d’écran 2023-03-01 à 11 02 06" src="https://user-images.githubusercontent.com/54004476/222107052-46b34b4d-709a-4b17-a991-38ba12456cbe.png">
